### PR TITLE
Add verify user middleware in backend #22

### DIFF
--- a/client/src/service/UserApi.js
+++ b/client/src/service/UserApi.js
@@ -7,11 +7,11 @@ const API = axios.create({
 
 // Register User
 export const registerUser = (user) =>
-  API.post("/user/register", user); // ✅ matches backend route
+  API.post("/user/registeruser", user); // ✅ matches backend route
 
 // Login User
 export const loginUser = (user) =>
-  API.post("/user/login", user); // ✅ matches backend route
+  API.post("/user/loginuser", user); // ✅ matches backend route
 
 // Logout User (optional)
 export const logoutUser = () =>

--- a/server/src/models/User.Model.js
+++ b/server/src/models/User.Model.js
@@ -12,7 +12,10 @@ const userSchema = new mongoose.Schema(
     resumeUsage: { type: Number, default: 0 },
     atsUsage: { type: Number, default: 0 },
     createdAt: { type: Date, default: Date.now },
-    refreshToken: String,
+    refreshTokens: {
+      type: [String],
+      default: [],
+    }
   },
   { timestamps: true }
 );

--- a/server/src/routes/User.Routes.js
+++ b/server/src/routes/User.Routes.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 
-import { registerUser, loginUser, logoutUser } from '../controllers/User.Controller.js';
+import { registerUser, loginUser, logoutUser, logoutAllDevices } from '../controllers/User.Controller.js';
 import { verifyJWT } from "../middlewares/auth.middleware.js";
 
 
@@ -13,6 +13,7 @@ const UserRouter = Router();
 UserRouter.route('/registeruser').post(registerUser);
 UserRouter.route('/loginuser').post(loginUser);
 UserRouter.post("/logout", verifyJWT, logoutUser);
+UserRouter.post("/logout-all", verifyJWT, logoutAllDevices);
 
 
 


### PR DESCRIPTION
**Multiple Device Login Handling Not Implemented:**

Users could log in from multiple devices/browsers, but logout logic did not differentiate between sessions.

Logout removed the single stored refresh token, which meant logging in from a second device overwrote the previous session.

**Changes Made**

refreshTokens: {
  type: [String],
  default: []
}

Why: This allows a user to maintain multiple active sessions across devices by storing multiple valid refresh tokens.

**Enhanced loginUser API
Logic Updated:**

Generates new access + refresh token.

Saves the refresh token in the refreshTokens array for that user.

**Updated logoutUser API
New Behavior:**

Accepts the current refresh token from cookies.

Removes only that token from the refreshTokens array using MongoDB $pull.

Clears cookies to invalidate client session.

**Why: This allows safe logout without affecting other sessions, solving the core of multi-device logout handling.**

**Added logoutAllDevices API
Route: POST /api/v1/user/logout-all

Behavior:**

Clears all refresh tokens for a user, effectively logging them out of all devices/browsers.

Why: Often required for account security, especially if the user suspects session hijacking.




Every thing is Working Cool 
