### PR TITLE
Implement API to Download resume in PDF

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,7 +17,8 @@
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.16.4",
-        "multer": "^2.0.1"
+        "multer": "^2.0.1",
+        "pdfkit": "^0.17.1"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
@@ -30,6 +31,15 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@types/webidl-conversions": {
@@ -102,6 +112,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bcrypt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -171,6 +201,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/bson": {
@@ -266,6 +305,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/combined-stream": {
@@ -372,6 +420,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -405,6 +459,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.2.0",
@@ -557,6 +617,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -604,6 +670,23 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/form-data": {
@@ -903,6 +986,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "license": "MIT"
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -953,6 +1042,25 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lodash.includes": {
@@ -1364,6 +1472,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1382,6 +1496,19 @@
         "node": ">=16"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.1.tgz",
+      "integrity": "sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1394,6 +1521,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1494,6 +1626,12 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -1731,6 +1869,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1775,6 +1919,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1801,6 +1951,26 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.4",
-    "multer": "^2.0.1"
+    "multer": "^2.0.1",
+    "pdfkit": "^0.17.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/server/src/controllers/User.Controller.js
+++ b/server/src/controllers/User.Controller.js
@@ -147,26 +147,38 @@ export const downloadResume = asyncHandler(async (req, res) => {
   if (id !== req.user._id.toString()) {
     throw new ApiError(403, "You can only download your own resume");
   }
-  const user = await User.findById(id);
-  if (!user || !user.resume) {
+  const user = await User.findById(id).select("name email phone resume");
+  if (!user) {
+    throw new ApiError(404, "User not found");
+  }
+  if (!user.resume) {
     throw new ApiError(404, "Resume not found");
   }
-  const resume = user.resume;
-  const doc = new PDFDocument();
+  const resume = user.resume;  const doc = new PDFDocument();
   res.setHeader('Content-Type', 'application/pdf');
   res.setHeader('Content-Disposition', 'attachment; filename=resume.pdf');
   doc.pipe(res);
-  doc.fontSize(20).text(user.name || resume.personalInfo.fullName || 'Name', { align: 'center' });
+  doc.fontSize(20).text(
+    user.name || resume.personalInfo?.fullName || 'Name',
+    { align: 'center' }
+  );
   doc.fontSize(12).text(`Email: ${user.email}`, { align: 'center' });
   doc.fontSize(12).text(`Phone: ${user.phone}`, { align: 'center' });
   doc.moveDown();
   doc.fontSize(14).text('Personal Information');
-  doc.fontSize(12).text(`Address: ${resume.personalInfo.address || ''}`);
-  doc.text(`LinkedIn: ${resume.personalInfo.linkedin || ''}`);
-  doc.text(`GitHub: ${resume.personalInfo.github || ''}`);
-  doc.text(`Portfolio: ${resume.personalInfo.portfolio || ''}`);
-  doc.moveDown();
-  if (resume.summary) {
+  doc.fontSize(12).text(
+    `Address: ${resume.personalInfo?.address || ''}`
+  );
+  doc.text(
+    `LinkedIn: ${resume.personalInfo?.linkedin || ''}`
+  );
+  doc.text(
+    `GitHub: ${resume.personalInfo?.github || ''}`
+  );
+  doc.text(
+    `Portfolio: ${resume.personalInfo?.portfolio || ''}`
+  );
+  doc.moveDown();  if (resume.summary) {
     doc.fontSize(14).text('Summary');
     doc.fontSize(12).text(resume.summary);
     doc.moveDown();

--- a/server/src/controllers/User.Controller.js
+++ b/server/src/controllers/User.Controller.js
@@ -3,6 +3,9 @@ import { User } from "../models/User.Model.js";
 import { generateAccessAndRefreshToken } from "../utils/GenerateAccessAndRefreshToken.js";
 import { ApiError } from "../utils/ApiError.js";
 import { ApiResponse } from "../utils/ApiResposne.js";
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const PDFDocument = require('pdfkit');
 
 // register user api
 export const registerUser = asyncHandler(async (req, res) => {
@@ -137,4 +140,82 @@ export const updateResume = asyncHandler(async (req, res) => {
   return res
     .status(200)
     .json(new ApiResponse(200, updatedUser, "Resume updated successfully"));
+});
+
+export const downloadResume = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  if (id !== req.user._id.toString()) {
+    throw new ApiError(403, "You can only download your own resume");
+  }
+  const user = await User.findById(id);
+  if (!user || !user.resume) {
+    throw new ApiError(404, "Resume not found");
+  }
+  const resume = user.resume;
+  const doc = new PDFDocument();
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', 'attachment; filename=resume.pdf');
+  doc.pipe(res);
+  doc.fontSize(20).text(user.name || resume.personalInfo.fullName || 'Name', { align: 'center' });
+  doc.fontSize(12).text(`Email: ${user.email}`, { align: 'center' });
+  doc.fontSize(12).text(`Phone: ${user.phone}`, { align: 'center' });
+  doc.moveDown();
+  doc.fontSize(14).text('Personal Information');
+  doc.fontSize(12).text(`Address: ${resume.personalInfo.address || ''}`);
+  doc.text(`LinkedIn: ${resume.personalInfo.linkedin || ''}`);
+  doc.text(`GitHub: ${resume.personalInfo.github || ''}`);
+  doc.text(`Portfolio: ${resume.personalInfo.portfolio || ''}`);
+  doc.moveDown();
+  if (resume.summary) {
+    doc.fontSize(14).text('Summary');
+    doc.fontSize(12).text(resume.summary);
+    doc.moveDown();
+  }
+  if (resume.experience && resume.experience.length > 0) {
+    doc.fontSize(14).text('Experience');
+    resume.experience.forEach(exp => {
+      doc.fontSize(12).text(`${exp.position} at ${exp.company}`);
+      doc.text(`${exp.startDate ? new Date(exp.startDate).toLocaleDateString() : ''} - ${exp.endDate ? new Date(exp.endDate).toLocaleDateString() : (exp.current ? 'Present' : '')}`);
+      doc.text(exp.description || '');
+      doc.moveDown(0.5);
+    });
+    doc.moveDown();
+  }
+  if (resume.education && resume.education.length > 0) {
+    doc.fontSize(14).text('Education');
+    resume.education.forEach(edu => {
+      doc.fontSize(12).text(`${edu.degree} in ${edu.field || ''}, ${edu.institution}`);
+      doc.text(`${edu.startDate ? new Date(edu.startDate).toLocaleDateString() : ''} - ${edu.endDate ? new Date(edu.endDate).toLocaleDateString() : ''}`);
+      doc.text(`GPA: ${edu.gpa || ''}`);
+      doc.moveDown(0.5);
+    });
+    doc.moveDown();
+  }
+  if (resume.skills && resume.skills.length > 0) {
+    doc.fontSize(14).text('Skills');
+    doc.fontSize(12).text(resume.skills.join(', '));
+    doc.moveDown();
+  }
+  if (resume.projects && resume.projects.length > 0) {
+    doc.fontSize(14).text('Projects');
+    resume.projects.forEach(proj => {
+      doc.fontSize(12).text(proj.name);
+      doc.text(proj.description || '');
+      doc.text(`Technologies: ${proj.technologies ? proj.technologies.join(', ') : ''}`);
+      doc.text(`GitHub: ${proj.github || ''}`);
+      doc.text(`Demo: ${proj.demo || ''}`);
+      doc.moveDown(0.5);
+    });
+    doc.moveDown();
+  }
+  if (resume.certifications && resume.certifications.length > 0) {
+    doc.fontSize(14).text('Certifications');
+    resume.certifications.forEach(cert => {
+      doc.fontSize(12).text(`${cert.name}, ${cert.issuer}`);
+      doc.text(`Date: ${cert.date ? new Date(cert.date).toLocaleDateString() : ''}`);
+      doc.text(`Credential ID: ${cert.credentialId || ''}`);
+      doc.moveDown(0.5);
+    });
+  }
+  doc.end();
 });

--- a/server/src/controllers/User.Controller.js
+++ b/server/src/controllers/User.Controller.js
@@ -107,3 +107,34 @@ export const logoutUser = asyncHandler(async (req, res) => {
     .json(new ApiResponse(200, {}, "User logged out"))
 
 });
+
+// Update resume for authenticated user
+export const updateResume = asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const { resume } = req.body;
+
+  // Ensure the user can only update their own resume
+  if (id !== req.user._id.toString()) {
+    throw new ApiError(403, "You can only update your own resume");
+  }
+
+  // Validate resume data
+  if (!resume || typeof resume !== 'object') {
+    throw new ApiError(400, "Valid resume data is required");
+  }
+
+  // Update the user's resume
+  const updatedUser = await User.findByIdAndUpdate(
+    id,
+    { $set: { resume } },
+    { new: true, runValidators: true }
+  ).select("-password -refreshToken");
+
+  if (!updatedUser) {
+    throw new ApiError(404, "User not found");
+  }
+
+  return res
+    .status(200)
+    .json(new ApiResponse(200, updatedUser, "Resume updated successfully"));
+});

--- a/server/src/models/User.Model.js
+++ b/server/src/models/User.Model.js
@@ -13,6 +13,48 @@ const userSchema = new mongoose.Schema(
     atsUsage: { type: Number, default: 0 },
     createdAt: { type: Date, default: Date.now },
     refreshToken: String,
+    resume: {
+      personalInfo: {
+        fullName: String,
+        email: String,
+        phone: String,
+        address: String,
+        linkedin: String,
+        github: String,
+        portfolio: String,
+      },
+      summary: String,
+      experience: [{
+        company: String,
+        position: String,
+        startDate: Date,
+        endDate: Date,
+        current: Boolean,
+        description: String,
+      }],
+      education: [{
+        institution: String,
+        degree: String,
+        field: String,
+        startDate: Date,
+        endDate: Date,
+        gpa: String,
+      }],
+      skills: [String],
+      projects: [{
+        name: String,
+        description: String,
+        technologies: [String],
+        github: String,
+        demo: String,
+      }],
+      certifications: [{
+        name: String,
+        issuer: String,
+        date: Date,
+        credentialId: String,
+      }],
+    },
   },
   { timestamps: true }
 );

--- a/server/src/models/User.Model.js
+++ b/server/src/models/User.Model.js
@@ -16,9 +16,13 @@ const userSchema = new mongoose.Schema(
     resume: {
       personalInfo: {
         fullName: String,
-        email: String,
-        phone: String,
-        address: String,
+ personalInfo: {
+   fullName: String,
+   address: String,
+   linkedin: String,
+   github: String,
+   portfolio: String,
+ },        address: String,
         linkedin: String,
         github: String,
         portfolio: String,

--- a/server/src/routes/User.Routes.js
+++ b/server/src/routes/User.Routes.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 
-import { registerUser, loginUser, logoutUser, updateResume } from '../controllers/User.Controller.js';
+import { registerUser, loginUser, logoutUser, updateResume, downloadResume } from '../controllers/User.Controller.js';
 import { verifyJWT } from "../middlewares/auth.middleware.js";
 
 
@@ -14,7 +14,7 @@ UserRouter.route('/registeruser').post(registerUser);
 UserRouter.route('/loginuser').post(loginUser);
 UserRouter.post("/logout", verifyJWT, logoutUser);
 UserRouter.put("/updateresume/:id", verifyJWT, updateResume);
-
+UserRouter.route('/downloadresume/:id/download').get(verifyJWT, downloadResume);
 
 
 export default UserRouter;

--- a/server/src/routes/User.Routes.js
+++ b/server/src/routes/User.Routes.js
@@ -1,6 +1,6 @@
 import { Router } from "express";
 
-import { registerUser, loginUser, logoutUser } from '../controllers/User.Controller.js';
+import { registerUser, loginUser, logoutUser, updateResume } from '../controllers/User.Controller.js';
 import { verifyJWT } from "../middlewares/auth.middleware.js";
 
 
@@ -13,6 +13,7 @@ const UserRouter = Router();
 UserRouter.route('/registeruser').post(registerUser);
 UserRouter.route('/loginuser').post(loginUser);
 UserRouter.post("/logout", verifyJWT, logoutUser);
+UserRouter.put("/updateresume/:id", verifyJWT, updateResume);
 
 
 


### PR DESCRIPTION
### Pull Request Summary: Implement Resume PDF Download Feature

**Title:** feat: Add resume PDF download endpoint using pdfkit

**Description:**  
This PR implements a new protected GET endpoint `/api/v1/user/downloadresume/:id/download` to download a user's resume as a PDF. It uses pdfkit for server-side PDF generation based on the structured resume data stored in the User model. The route is authenticated and restricted to the user's own resume. Includes installation of pdfkit dependency and necessary code updates to the user controller and routes. Minor refinements were made to handle optional fields and improve error checking.

**Changes Overview:**  
- Installed `pdfkit` in the server directory.  
- Added PDF generation logic in `server/src/controllers/User.Controller.js`.  
- Added new route in `server/src/routes/User.Routes.js`.  
- Incorporated user's additional tweaks for optional chaining and error handling.

**Installation Steps (Run in server directory):**  
```
npm install pdfkit --save
```

**Testing Instructions:**  
- Ensure the server is running.  
- Authenticate as a user and hit `GET /api/v1/user/downloadresume/:id/download` with a valid user ID (your own).  
- Verify a PDF is downloaded with the resume content.

**Related Issues:** 
[ISSUE]#27